### PR TITLE
adding support for picking UEFI or UNDI based on client options

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,8 +38,10 @@ var (
 		"static hostname to be handed out in dhcp offers, is ignored if dynamic-hostname is enabled",
 	)
 	flagDomainname = flag.String("domain-name", "local", "domainname to be handed out in dhcp offers")
-	flagHTTPUrl    = flag.String("http-url", "", "url to serve uefi http client")
-	flagiPXE       = flag.String("iPXE", "", "url to serve iPXE user-class")
+	flagHTTPUrl    = flag.String("http-url", "", "url to serve UNDI http client (alias for bios-url)")
+	flagiPXE       = flag.String("iPXE", "", "url to serve iPXE config (eg. boot.ipxe)")
+	flagBiosUrl    = flag.String("bios-url", "", "url to serve UNDI http client")
+	flagUefiUrl    = flag.String("uefi-url", "", "url to serve UEFI http client")
 
 	logLevels = map[string]func(){
 		"none":    func() { ll.SetOutput(ioutil.Discard) },


### PR DESCRIPTION
This PR adds the IsUsingUEFI function to pick between UEFI or UNDI, and adds the command line parameters uefi-url and bios-url; http-url is now an alias for bios-url. If bios-url and uefi-url are specified, dhcp will use IsUsingUEFI to determine the boot mode and serve the correct firmware.