### PR TITLE
Protect against a race between NDP table and kernel

### DIFF
--- a/handle.go
+++ b/handle.go
@@ -121,7 +121,7 @@ func (l *Listener) HandleMsg6(buf []byte, oob *ipv6.ControlMessage, peer *net.UD
 	// This filters out embedded processors like NVIDIA BlueField ECPF that
 	// use software-assigned MACs on the host-facing link.
 	if *flagIgnoreVirtualMAC {
-		if peerMAC := neighLookupMAC(peer.IP, l.ifi.Index); peerMAC != nil && isVirtualMAC(peerMAC) {
+		if peerMAC := neighLookupMAC(peer.IP, l.ifi.Index); peerMAC == nil || isVirtualMAC(peerMAC) {
 			ll.Infof("handleMsg6: ignoring request from virtual MAC %s (peer %s) on %s",
 				peerMAC, peer.IP, l.ifi.Name)
 			return


### PR DESCRIPTION
Secure against a nil MAC of peer which can be caused by a race between kernel NDP table and the go code.