### PR TITLE
Access the request source MAC directly by listening on a RAW SOCKET

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dhcpd-unnumbered
 dhcpv6d-unnumbered
 dhcpd6-unnumbered
 dhcpd6-unnumbered.gz
+dhcpv6test
 
 # Makefile artifacts
 generated_version

--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@
 ### NOTES:
 - Currently the server hands out ia_na non-temporary address, dns servers, domain-name, search domain, hostname.  RA's are still needed for the default gw, set a nd-prefix in the accepted prefix range with the offlink flag set, managed-flag set, and other config flag set.
 
+### VLAN / 802.1Q:
+Bind to a **VLAN sub-interface**, not the trunk. On a trunk, 802.1Q-tagged frames have EtherType `0x8100` and are invisible to the raw socket — the daemon receives nothing.
+```
+dhcpd6-unnumbered -regex "^eth0\.100$" ...   # correct
+dhcpd6-unnumbered -regex "^eth0$" ...        # broken if eth0 is a trunk
+```
+
 ### Usage:
 ```
 dhcpd6-unnumbered -help

--- a/cmd/dhcpv6test/main.go
+++ b/cmd/dhcpv6test/main.go
@@ -81,23 +81,40 @@ func buildSolicit(mac net.HardwareAddr) []byte {
 }
 
 // udpChecksum computes the UDP checksum over the IPv6 pseudo-header.
+// RFC 2460 §8.1: the pseudo-header contains src IP, dst IP, upper-layer
+// packet length, and next-header, followed by the UDP segment itself.
 func udpChecksum(srcIP, dstIP net.IP, udpSeg []byte) uint16 {
+	// IPv6 pseudo-header (40 bytes) layout:
+	//   [0:16]  source address
+	//   [16:32] destination address
+	//   [32:36] upper-layer packet length (32-bit, same value as UDP length field)
+	//   [36:39] zeros (reserved)
+	//   [39]    next-header (17 = UDP)
+	// followed immediately by the UDP segment.
 	pseudo := make([]byte, 40+len(udpSeg))
 	copy(pseudo[0:16], srcIP)
 	copy(pseudo[16:32], dstIP)
 	binary.BigEndian.PutUint32(pseudo[32:36], uint32(len(udpSeg)))
-	pseudo[39] = 17 // next header: UDP
+	pseudo[39] = 17 // next-header: UDP
 	copy(pseudo[40:], udpSeg)
+
+	// RFC 1071 one's-complement sum: accumulate 16-bit words.
 	var sum uint32
 	for i := 0; i+1 < len(pseudo); i += 2 {
 		sum += uint32(binary.BigEndian.Uint16(pseudo[i : i+2]))
 	}
+	// If the payload has an odd number of bytes, pad the final byte on the
+	// left (big-endian), i.e. treat it as the high byte of a 16-bit word.
 	if len(pseudo)%2 != 0 {
 		sum += uint32(pseudo[len(pseudo)-1]) << 8
 	}
+	// Fold the 32-bit accumulator down to 16 bits by adding the carry bits
+	// (upper 16) back into the lower 16, repeating until no carry remains.
 	for sum>>16 != 0 {
 		sum = (sum & 0xffff) + (sum >> 16)
 	}
+	// One's complement: flip all bits. A receiver summing the segment
+	// (including this checksum field) gets 0xffff if no errors occurred.
 	return ^uint16(sum)
 }
 

--- a/cmd/dhcpv6test/main.go
+++ b/cmd/dhcpv6test/main.go
@@ -1,0 +1,307 @@
+// dhcpv6test sends DHCPv6 Solicit packets over raw Ethernet frames (AF_PACKET)
+// so the source MAC is visible to dhcpd6-unnumbered exactly as it is in
+// production.  Two cases are exercised:
+//
+//   - Normal (globally-unique) MAC  → expect Advertise / Reply
+//   - Virtual (locally-administered) MAC → expect silence (ignored by server)
+//
+// Requires CAP_NET_RAW (run as root).
+package main
+
+import (
+	"encoding/binary"
+	"flag"
+	"fmt"
+	"net"
+	"os"
+	"syscall"
+	"time"
+
+	"github.com/insomniacslk/dhcp/dhcpv6"
+	"github.com/insomniacslk/dhcp/iana"
+)
+
+const (
+	etherHeaderLen   = 14
+	ipv6HeaderLen    = 40
+	udpHeaderLen     = 8
+	etherTypeIPv6    = 0x86DD
+	dhcpv6ClientPort = 546
+	dhcpv6ServerPort = 547
+)
+
+func htons(i uint16) uint16 { return (i<<8)&0xff00 | i>>8 }
+
+// getLinkLocalAddr returns the first link-local IPv6 address on the interface.
+// The server sends replies to this address, so we use it as the IPv6 source in
+// every test frame regardless of the Ethernet source MAC being tested.
+func getLinkLocalAddr(ifi *net.Interface) (net.IP, error) {
+	addrs, err := ifi.Addrs()
+	if err != nil {
+		return nil, err
+	}
+	for _, a := range addrs {
+		var ip net.IP
+		switch v := a.(type) {
+		case *net.IPNet:
+			ip = v.IP
+		case *net.IPAddr:
+			ip = v.IP
+		}
+		if ip != nil && ip.IsLinkLocalUnicast() && ip.To4() == nil {
+			return ip.To16(), nil
+		}
+	}
+	return nil, fmt.Errorf("no link-local IPv6 address found on %s", ifi.Name)
+}
+
+// buildSolicit constructs a minimal DHCPv6 Solicit with the given MAC in its DUID.
+func buildSolicit(mac net.HardwareAddr) []byte {
+	duid := dhcpv6.Duid{
+		Type:          dhcpv6.DUID_LL,
+		HwType:        iana.HWTypeEthernet,
+		LinkLayerAddr: mac,
+	}
+	msg, err := dhcpv6.NewMessage()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "dhcpv6.NewMessage: %v\n", err)
+		os.Exit(1)
+	}
+	msg.MessageType = dhcpv6.MessageTypeSolicit
+	msg.Options.Add(dhcpv6.OptClientID(duid))
+	msg.Options.Add(&dhcpv6.OptIANA{
+		IaId: [4]byte{mac[2], mac[3], mac[4], mac[5]},
+	})
+	msg.Options.Add(dhcpv6.OptRequestedOption(
+		dhcpv6.OptionDNSRecursiveNameServer,
+		dhcpv6.OptionDomainSearchList,
+		dhcpv6.OptionFQDN,
+	))
+	return msg.ToBytes()
+}
+
+// udpChecksum computes the UDP checksum over the IPv6 pseudo-header.
+func udpChecksum(srcIP, dstIP net.IP, udpSeg []byte) uint16 {
+	pseudo := make([]byte, 40+len(udpSeg))
+	copy(pseudo[0:16], srcIP)
+	copy(pseudo[16:32], dstIP)
+	binary.BigEndian.PutUint32(pseudo[32:36], uint32(len(udpSeg)))
+	pseudo[39] = 17 // next header: UDP
+	copy(pseudo[40:], udpSeg)
+	var sum uint32
+	for i := 0; i+1 < len(pseudo); i += 2 {
+		sum += uint32(binary.BigEndian.Uint16(pseudo[i : i+2]))
+	}
+	if len(pseudo)%2 != 0 {
+		sum += uint32(pseudo[len(pseudo)-1]) << 8
+	}
+	for sum>>16 != 0 {
+		sum = (sum & 0xffff) + (sum >> 16)
+	}
+	return ^uint16(sum)
+}
+
+// buildEthernetFrame wraps a DHCPv6 payload inside UDP/IPv6/Ethernet destined
+// for the DHCPv6 all-servers multicast address.
+func buildEthernetFrame(srcMAC net.HardwareAddr, srcIP net.IP, payload []byte) []byte {
+	dstMAC := net.HardwareAddr{0x33, 0x33, 0x00, 0x01, 0x00, 0x02}
+	dstIP := dhcpv6.AllDHCPRelayAgentsAndServers.To16()
+	udpLen := udpHeaderLen + len(payload)
+	frame := make([]byte, etherHeaderLen+ipv6HeaderLen+udpLen)
+
+	copy(frame[0:6], dstMAC)
+	copy(frame[6:12], srcMAC)
+	binary.BigEndian.PutUint16(frame[12:14], etherTypeIPv6)
+
+	ip := frame[etherHeaderLen:]
+	ip[0] = 0x60
+	binary.BigEndian.PutUint16(ip[4:6], uint16(udpLen))
+	ip[6] = 17  // next header: UDP
+	ip[7] = 255 // hop limit
+	copy(ip[8:24], srcIP)
+	copy(ip[24:40], dstIP)
+
+	udp := ip[ipv6HeaderLen:]
+	binary.BigEndian.PutUint16(udp[0:2], dhcpv6ClientPort)
+	binary.BigEndian.PutUint16(udp[2:4], dhcpv6ServerPort)
+	binary.BigEndian.PutUint16(udp[4:6], uint16(udpLen))
+	copy(udp[8:], payload)
+	binary.BigEndian.PutUint16(udp[6:8], udpChecksum(srcIP, dstIP, udp))
+	return frame
+}
+
+// parseReply checks whether a received Ethernet frame is a DHCPv6
+// Advertise or Reply addressed to ourIP on port 546.
+func parseReply(frame []byte, ourIP net.IP) *dhcpv6.Message {
+	if len(frame) < etherHeaderLen+ipv6HeaderLen+udpHeaderLen {
+		return nil
+	}
+	if binary.BigEndian.Uint16(frame[12:14]) != etherTypeIPv6 {
+		return nil
+	}
+	ip := frame[etherHeaderLen:]
+	if ip[6] != 17 {
+		return nil
+	}
+	if !net.IP(ip[24:40]).Equal(ourIP) {
+		return nil
+	}
+	udp := ip[ipv6HeaderLen:]
+	if len(udp) < udpHeaderLen {
+		return nil
+	}
+	if binary.BigEndian.Uint16(udp[2:4]) != dhcpv6ClientPort {
+		return nil
+	}
+	raw, err := dhcpv6.FromBytes(udp[udpHeaderLen:])
+	if err != nil {
+		return nil
+	}
+	msg, err := raw.GetInnerMessage()
+	if err != nil {
+		return nil
+	}
+	t := msg.Type()
+	if t == dhcpv6.MessageTypeAdvertise || t == dhcpv6.MessageTypeReply {
+		return msg
+	}
+	return nil
+}
+
+// runTest sends a Solicit from srcMAC/srcIP and waits up to timeout for a reply.
+// Returns true when the outcome matches wantReply.
+func runTest(ifi *net.Interface, srcIP net.IP, label string, mac net.HardwareAddr, wantReply bool, timeout time.Duration) bool {
+	fmt.Printf("\n─── %s ───\n", label)
+	fmt.Printf("  MAC:       %s  (locally-administered: %v)\n", mac, mac[0]&0x02 != 0)
+	fmt.Printf("  IPv6 src:  %s\n", srcIP)
+	fmt.Printf("  Expecting: ")
+	if wantReply {
+		fmt.Println("DHCPv6 Advertise / Reply")
+	} else {
+		fmt.Println("silence  (virtual MAC must be ignored by server)")
+	}
+
+	// Open the receive socket before sending to avoid a race.
+	rfd, err := syscall.Socket(syscall.AF_PACKET, syscall.SOCK_RAW, int(htons(syscall.ETH_P_IPV6)))
+	if err != nil {
+		fmt.Printf("  FAIL: open recv socket: %v\n", err)
+		return false
+	}
+	defer syscall.Close(rfd) //nolint:errcheck
+	if err := syscall.Bind(rfd, &syscall.SockaddrLinklayer{
+		Protocol: htons(syscall.ETH_P_IPV6),
+		Ifindex:  ifi.Index,
+	}); err != nil {
+		fmt.Printf("  FAIL: bind recv socket: %v\n", err)
+		return false
+	}
+	tv := syscall.NsecToTimeval(timeout.Nanoseconds())
+	if err := syscall.SetsockoptTimeval(rfd, syscall.SOL_SOCKET, syscall.SO_RCVTIMEO, &tv); err != nil {
+		fmt.Printf("  FAIL: set SO_RCVTIMEO: %v\n", err)
+		return false
+	}
+
+	sfd, err := syscall.Socket(syscall.AF_PACKET, syscall.SOCK_RAW, int(htons(syscall.ETH_P_IPV6)))
+	if err != nil {
+		fmt.Printf("  FAIL: open send socket: %v\n", err)
+		return false
+	}
+	defer syscall.Close(sfd) //nolint:errcheck
+
+	frame := buildEthernetFrame(mac, srcIP, buildSolicit(mac))
+	if err := syscall.Sendto(sfd, frame, 0, &syscall.SockaddrLinklayer{
+		Protocol: htons(syscall.ETH_P_IPV6),
+		Ifindex:  ifi.Index,
+	}); err != nil {
+		fmt.Printf("  FAIL: sendto: %v\n", err)
+		return false
+	}
+	fmt.Println("  → Solicit sent")
+
+	buf := make([]byte, 1<<16)
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		n, _, err := syscall.Recvfrom(rfd, buf, 0)
+		if err != nil {
+			break // EAGAIN / timeout
+		}
+		msg := parseReply(buf[:n], srcIP)
+		if msg == nil {
+			continue
+		}
+		offeredIP := "<no address in IANA>"
+		if optIANA := msg.Options.OneIANA(); optIANA != nil {
+			if a := optIANA.Options.OneAddress(); a != nil {
+				offeredIP = a.IPv6Addr.String()
+			}
+		}
+		if wantReply {
+			fmt.Printf("  ← %s received — offered IP: %s\n", msg.Type(), offeredIP)
+			fmt.Println("  PASS ✓")
+			return true
+		}
+		fmt.Printf("  FAIL: unexpected %s received for virtual MAC\n", msg.Type())
+		return false
+	}
+
+	if wantReply {
+		fmt.Println("  FAIL: no reply within timeout")
+		fmt.Println("        (is a /128 host route configured on the interface?)")
+		return false
+	}
+	fmt.Println("  ← (silence) — virtual MAC correctly ignored")
+	fmt.Println("  PASS ✓")
+	return true
+}
+
+func main() {
+	flagIfi := flag.String("interface", "", "interface to test on (required)")
+	flagTimeout := flag.Duration("timeout", 3*time.Second, "per-test reply timeout")
+	flag.Parse()
+
+	if *flagIfi == "" {
+		fmt.Fprintln(os.Stderr, "usage: dhcpv6test -interface <name> [-timeout 3s]")
+		fmt.Fprintln(os.Stderr, "requires CAP_NET_RAW (run as root)")
+		os.Exit(1)
+	}
+
+	ifi, err := net.InterfaceByName(*flagIfi)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "interface %q: %v\n", *flagIfi, err)
+		os.Exit(1)
+	}
+	srcIP, err := getLinkLocalAddr(ifi)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	tests := []struct {
+		label     string
+		mac       net.HardwareAddr
+		wantReply bool
+	}{
+		{
+			"Normal (globally-unique) MAC — server must reply",
+			net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55},
+			true,
+		},
+		{
+			"Virtual (locally-administered) MAC — server must ignore",
+			net.HardwareAddr{0x02, 0x00, 0x00, 0x00, 0x00, 0x01},
+			false,
+		},
+	}
+
+	pass := 0
+	for _, tc := range tests {
+		if runTest(ifi, srcIP, tc.label, tc.mac, tc.wantReply, *flagTimeout) {
+			pass++
+		}
+	}
+
+	fmt.Printf("\n%d/%d tests passed\n", pass, len(tests))
+	if pass != len(tests) {
+		os.Exit(1)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,10 +7,10 @@ require (
 	github.com/sirupsen/logrus v1.9.0
 	github.com/vishvananda/netlink v1.1.0
 	golang.org/x/net v0.1.0
+	golang.org/x/sys v0.1.0
 )
 
 require (
 	github.com/u-root/uio v0.0.0-20220204230159-dac05f7d2cb4 // indirect
 	github.com/vishvananda/netns v0.0.0-20220913150850-18c4f4234207 // indirect
-	golang.org/x/sys v0.1.0 // indirect
 )

--- a/handle.go
+++ b/handle.go
@@ -121,7 +121,7 @@ func (l *Listener) HandleMsg6(buf []byte, oob *ipv6.ControlMessage, peer *net.UD
 	// This filters out embedded processors like NVIDIA BlueField ECPF that
 	// use software-assigned MACs on the host-facing link.
 	if *flagIgnoreVirtualMAC {
-		if len(srcMAC) == 0 || isVirtualMAC(srcMAC) {
+		if isVirtualMAC(srcMAC) {
 			ll.Infof("handleMsg6: ignoring request from virtual MAC %s (peer %s) on %s",
 				srcMAC, peer.IP, l.ifi.Name)
 			return

--- a/handle.go
+++ b/handle.go
@@ -282,8 +282,6 @@ func (l *Listener) HandleMsg6(buf []byte, oob *ipv6.ControlMessage, peer *net.UD
 		}
 	}
 
-	woob := &ipv6.ControlMessage{IfIndex: oob.IfIndex}
-
 	ll.Infof(
 		"%s to %s on %s with %s, lease %gm, fqdn %s",
 		resp.Type(),
@@ -295,7 +293,7 @@ func (l *Listener) HandleMsg6(buf []byte, oob *ipv6.ControlMessage, peer *net.UD
 	)
 	ll.Trace(resp.Summary())
 
-	if _, err := l.c.WriteTo(resp.ToBytes(), woob, peer); err != nil {
+	if _, err := l.c.WriteTo(resp.ToBytes(), &ipv6.ControlMessage{IfIndex: oob.IfIndex}, peer); err != nil {
 		ll.Warnf("handleMsg6: write to connection %v failed: %v", peer, err)
 	}
 }

--- a/handle.go
+++ b/handle.go
@@ -32,10 +32,16 @@ func IsUsingUEFI(msg *dhcpv6.Message) bool {
 
 // logClientInfo logs detailed information about a DHCPv6 client request
 // to help discriminate between different types of clients
-func logClientInfo(msg *dhcpv6.Message, peer *net.UDPAddr, ifIndex int) {
+func logClientInfo(msg *dhcpv6.Message, peer *net.UDPAddr, srcMAC net.HardwareAddr) {
 	fields := ll.Fields{
 		"msg_type": msg.Type().String(),
 		"peer":     peer.IP.String(),
+	}
+
+	// Source MAC observed directly from the Ethernet frame header.
+	if len(srcMAC) > 0 {
+		fields["src_mac"] = srcMAC.String()
+		fields["mac_locally_administered"] = isVirtualMAC(srcMAC)
 	}
 
 	// Client DUID (primary client identifier)
@@ -43,17 +49,11 @@ func logClientInfo(msg *dhcpv6.Message, peer *net.UDPAddr, ifIndex int) {
 		fields["duid_type"] = fmt.Sprintf("%v", cid.Type)
 		fields["hw_type"] = fmt.Sprintf("%v", cid.HwType)
 		if len(cid.LinkLayerAddr) > 0 {
-			fields["client_mac"] = cid.LinkLayerAddr.String()
-			fields["mac_locally_administered"] = isVirtualMAC(cid.LinkLayerAddr)
+			fields["duid_mac"] = cid.LinkLayerAddr.String()
 		}
 		if cid.EnterpriseNumber != 0 {
 			fields["enterprise_number"] = cid.EnterpriseNumber
 		}
-	}
-
-	// MAC from kernel neighbor cache
-	if peerMAC := neighLookupMAC(peer.IP, ifIndex); peerMAC != nil {
-		fields["peer_mac"] = peerMAC.String()
 	}
 
 	// Architecture types (e.g. UEFI, BIOS)
@@ -95,7 +95,7 @@ func logClientInfo(msg *dhcpv6.Message, peer *net.UDPAddr, ifIndex int) {
 }
 
 // handleMsg is triggered every time there is a DHCPv6 request coming in.
-func (l *Listener) HandleMsg6(buf []byte, oob *ipv6.ControlMessage, peer *net.UDPAddr) {
+func (l *Listener) HandleMsg6(buf []byte, oob *ipv6.ControlMessage, peer *net.UDPAddr, srcMAC net.HardwareAddr) {
 	if oob.IfIndex != l.ifi.Index {
 		ll.Errorf("handleMsg6: request not on listening socket....%d != %d", oob.IfIndex, l.ifi.Index)
 		return
@@ -114,16 +114,16 @@ func (l *Listener) HandleMsg6(buf []byte, oob *ipv6.ControlMessage, peer *net.UD
 
 	// Log client identity information for discrimination / debugging
 	if ll.IsLevelEnabled(ll.DebugLevel) {
-		logClientInfo(msg, peer, l.ifi.Index)
+		logClientInfo(msg, peer, srcMAC)
 	}
 
 	// Ignore clients with locally-administered (virtual) source MAC addresses.
 	// This filters out embedded processors like NVIDIA BlueField ECPF that
 	// use software-assigned MACs on the host-facing link.
 	if *flagIgnoreVirtualMAC {
-		if peerMAC := neighLookupMAC(peer.IP, l.ifi.Index); peerMAC == nil || isVirtualMAC(peerMAC) {
+		if len(srcMAC) == 0 || isVirtualMAC(srcMAC) {
 			ll.Infof("handleMsg6: ignoring request from virtual MAC %s (peer %s) on %s",
-				peerMAC, peer.IP, l.ifi.Name)
+				srcMAC, peer.IP, l.ifi.Name)
 			return
 		}
 	}

--- a/helper.go
+++ b/helper.go
@@ -141,13 +141,10 @@ func linkReady(l *netlink.LinkAttrs) bool {
 	return false
 }
 
-func checkNetOpError(err error) error {
-	if err != nil {
-		if strings.Contains(err.Error(), "use of closed network connection") {
-			return nil
-		}
-	}
-	return err
+// htons converts a uint16 from host byte order to network byte order (big-endian),
+// as required when passing protocol constants to AF_PACKET sockets on Linux.
+func htons(i uint16) uint16 {
+	return (i<<8)&0xff00 | i>>8
 }
 
 // isVirtualMAC returns true if the MAC address has the locally-administered
@@ -158,26 +155,4 @@ func isVirtualMAC(mac net.HardwareAddr) bool {
 		return false
 	}
 	return mac[0]&0x02 != 0
-}
-
-// neighLookupMAC looks up the hardware address for the given IP in the
-// kernel's neighbor cache (NDP table) for the specified interface.
-// Returns nil if no entry is found.
-func neighLookupMAC(ip net.IP, ifIndex int) net.HardwareAddr {
-	link, err := netlink.LinkByIndex(ifIndex)
-	if err != nil {
-		ll.Debugf("neighLookupMAC: failed to get link for ifIndex %d: %v", ifIndex, err)
-		return nil
-	}
-	neighs, err := netlink.NeighList(link.Attrs().Index, netlink.FAMILY_V6)
-	if err != nil {
-		ll.Debugf("neighLookupMAC: failed to list neighbors: %v", err)
-		return nil
-	}
-	for _, n := range neighs {
-		if n.IP.Equal(ip) && len(n.HardwareAddr) > 0 {
-			return n.HardwareAddr
-		}
-	}
-	return nil
 }

--- a/listener.go
+++ b/listener.go
@@ -13,7 +13,9 @@ import (
 	"github.com/insomniacslk/dhcp/dhcpv6/server6"
 
 	ll "github.com/sirupsen/logrus"
+	"golang.org/x/net/bpf"
 	"golang.org/x/net/ipv6"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -55,14 +57,25 @@ func NewListener(idx int, o *ListenerOptions) (*Listener, error) {
 		return nil, fmt.Errorf("unable to get interface: %v", err)
 	}
 
-	addr := net.UDPAddr{
+	// Bind the send socket to [::]:547 on the interface — NOT to the multicast
+	// group address.  If bound to ff02::1:2, Linux refuses to use a multicast
+	// address as the source of a unicast reply (EADDRNOTAVAIL).  We join the
+	// multicast group separately below so the kernel still delivers incoming
+	// multicast solicits to the network stack (needed for multicast group
+	// membership and NIC hardware filter).
+	mcastAddr := net.UDPAddr{
 		IP:   dhcpv6.AllDHCPRelayAgentsAndServers,
+		Port: dhcpv6.DefaultServerPort,
+		Zone: ifi.Name,
+	}
+	bindAddr := net.UDPAddr{
+		IP:   net.IPv6zero,
 		Port: dhcpv6.DefaultServerPort,
 		Zone: ifi.Name,
 	}
 
 	ll.Infof("Starting DHCPv6 server for Interface %s", ifi.Name)
-	udpConn, err := server6.NewIPv6UDPConn(addr.Zone, &addr)
+	udpConn, err := server6.NewIPv6UDPConn(ifi.Name, &bindAddr)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +86,7 @@ func NewListener(idx int, o *ListenerOptions) (*Listener, error) {
 	}
 	// Join the multicast group so the kernel (and NIC hardware filter) accepts
 	// incoming DHCPv6 multicast frames on this interface.
-	if err := c.JoinGroup(ifi, &addr); err != nil {
+	if err := c.JoinGroup(ifi, &mcastAddr); err != nil {
 		_ = c.Close()
 		return nil, err
 	}
@@ -96,6 +109,13 @@ func NewListener(idx int, o *ListenerOptions) (*Listener, error) {
 		_ = syscall.Close(rawFd)
 		_ = c.Close()
 		return nil, fmt.Errorf("failed to bind raw packet socket: %w", err)
+	}
+	// Attach a BPF filter so the kernel discards all non-DHCPv6 frames before
+	// copying them to userspace: IPv6 / UDP / dst-port 547.
+	if err := attachDHCPv6Filter(rawFd); err != nil {
+		_ = syscall.Close(rawFd)
+		_ = c.Close()
+		return nil, fmt.Errorf("failed to attach BPF filter: %w", err)
 	}
 
 	return &Listener{
@@ -196,4 +216,52 @@ func parseEthernetFrame(frame []byte) (srcMAC net.HardwareAddr, dhcpPayload []by
 		IP:   srcIP,
 		Port: int(binary.BigEndian.Uint16(udpFrame[0:2])),
 	}, nil
+}
+
+// dhcpv6FilterInstructions returns the classic BPF instructions that select
+// only IPv6/UDP frames destined for DHCPv6 server port 547.
+//
+// Frame layout assumed (no 802.1Q VLAN tag):
+//
+//	[12:14] EtherType (must be 0x86DD for IPv6)
+//	[20]    IPv6 next-header (byte 6 of the 40-byte IPv6 header)
+//	[56:58] UDP destination port (14 + 40 + 2)
+func dhcpv6FilterInstructions() []bpf.Instruction {
+	return []bpf.Instruction{
+		// 0: load EtherType halfword
+		bpf.LoadAbsolute{Off: 12, Size: 2},
+		// 1: drop if not IPv6 (0x86DD)
+		bpf.JumpIf{Cond: bpf.JumpEqual, Val: 0x86DD, SkipTrue: 0, SkipFalse: 5},
+		// 2: load IPv6 next-header byte
+		bpf.LoadAbsolute{Off: 20, Size: 1},
+		// 3: drop if not UDP (17)
+		bpf.JumpIf{Cond: bpf.JumpEqual, Val: 17, SkipTrue: 0, SkipFalse: 3},
+		// 4: load UDP destination port halfword
+		bpf.LoadAbsolute{Off: 56, Size: 2},
+		// 5: accept if dst port == 547, else drop
+		bpf.JumpIf{Cond: bpf.JumpEqual, Val: uint32(dhcpv6.DefaultServerPort), SkipTrue: 0, SkipFalse: 1},
+		// 6: accept — return full packet length
+		bpf.RetConstant{Val: 0xFFFF},
+		// 7: drop — return 0
+		bpf.RetConstant{Val: 0},
+	}
+}
+
+// attachDHCPv6Filter installs a classic BPF filter on fd that passes only
+// IPv6/UDP frames destined for DHCPv6 server port 547 (0x0223).
+func attachDHCPv6Filter(fd int) error {
+	insts, err := bpf.Assemble(dhcpv6FilterInstructions())
+	if err != nil {
+		return fmt.Errorf("bpf assemble: %w", err)
+	}
+
+	filters := make([]unix.SockFilter, len(insts))
+	for i, ri := range insts {
+		filters[i] = unix.SockFilter{Code: ri.Op, Jt: ri.Jt, Jf: ri.Jf, K: ri.K}
+	}
+	prog := unix.SockFprog{
+		Len:    uint16(len(filters)),
+		Filter: &filters[0],
+	}
+	return unix.SetsockoptSockFprog(fd, syscall.SOL_SOCKET, syscall.SO_ATTACH_FILTER, &prog)
 }

--- a/listener.go
+++ b/listener.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"encoding/binary"
+	"errors"
 	"fmt"
 	"net"
+	"os"
 	"regexp"
-	"sync"
+	"syscall"
 
 	"github.com/insomniacslk/dhcp/dhcpv6"
 	"github.com/insomniacslk/dhcp/dhcpv6/server6"
@@ -13,13 +16,19 @@ import (
 	"golang.org/x/net/ipv6"
 )
 
-var bufpool = sync.Pool{New: func() interface{} { r := make([]byte, MaxDatagram); return &r }}
+const (
+	etherHeaderLen = 14
+	ipv6HeaderLen  = 40
+	udpHeaderLen   = 8
+	etherTypeIPv6  = 0x86DD
+)
 
 // Listener is the core struct
 type Listener struct {
-	c     *ipv6.PacketConn
-	ifi   *net.Interface
-	Flags *ListenerOptions
+	c       *ipv6.PacketConn // send-only: used to write DHCPv6 replies
+	rawFile *os.File         // AF_PACKET raw socket: receives Ethernet frames so we see the source MAC directly
+	ifi     *net.Interface
+	Flags   *ListenerOptions
 }
 
 type ListenerOptions struct {
@@ -32,7 +41,14 @@ func (lo *ListenerOptions) SetPrefix(p *net.IPNet) {
 	lo.prefix = p
 }
 
-// NewListener creates a new instance of DHCP listener
+// NewListener creates a new instance of DHCP listener.
+// It opens two sockets on the interface:
+//   - a UDP socket joined to the DHCPv6 all-servers multicast group, used only
+//     for sending replies (multicast group membership is required so the kernel
+//     passes the incoming multicast frames to the network stack);
+//   - an AF_PACKET raw socket used for receiving, so that every Ethernet frame
+//     is available in full and the source MAC can be read directly from the
+//     frame header without relying on the kernel neighbor cache.
 func NewListener(idx int, o *ListenerOptions) (*Listener, error) {
 	ifi, err := net.InterfaceByIndex(idx)
 	if err != nil {
@@ -48,41 +64,136 @@ func NewListener(idx int, o *ListenerOptions) (*Listener, error) {
 	ll.Infof("Starting DHCPv6 server for Interface %s", ifi.Name)
 	udpConn, err := server6.NewIPv6UDPConn(addr.Zone, &addr)
 	if err != nil {
-		//ll.Warnf("failed to create a UDP Conn for Ifi %s: %s", ifi.Name, err)
 		return nil, err
 	}
 	c := ipv6.NewPacketConn(udpConn)
 	if err := c.SetControlMessage(ipv6.FlagInterface, true); err != nil {
+		_ = c.Close()
 		return nil, err
 	}
+	// Join the multicast group so the kernel (and NIC hardware filter) accepts
+	// incoming DHCPv6 multicast frames on this interface.
 	if err := c.JoinGroup(ifi, &addr); err != nil {
+		_ = c.Close()
 		return nil, err
 	}
 
+	// Open an AF_PACKET raw socket so we receive the full Ethernet frame and
+	// can extract the source MAC without consulting the neighbor cache.
+	rawFd, err := syscall.Socket(
+		syscall.AF_PACKET,
+		syscall.SOCK_RAW|syscall.SOCK_NONBLOCK|syscall.SOCK_CLOEXEC,
+		int(htons(syscall.ETH_P_IPV6)),
+	)
+	if err != nil {
+		_ = c.Close()
+		return nil, fmt.Errorf("failed to create raw packet socket: %w", err)
+	}
+	if err := syscall.Bind(rawFd, &syscall.SockaddrLinklayer{
+		Protocol: htons(syscall.ETH_P_IPV6),
+		Ifindex:  idx,
+	}); err != nil {
+		_ = syscall.Close(rawFd)
+		_ = c.Close()
+		return nil, fmt.Errorf("failed to bind raw packet socket: %w", err)
+	}
+
 	return &Listener{
-		c:     c,
-		ifi:   ifi,
-		Flags: o,
+		c:       c,
+		rawFile: os.NewFile(uintptr(rawFd), ifi.Name),
+		ifi:     ifi,
+		Flags:   o,
 	}, nil
 }
 
 func (l *Listener) Close() error {
+	// Close the raw socket first so Listen() unblocks, then close the send conn.
+	_ = l.rawFile.Close()
 	return l.c.Close()
 }
 
-// Listen staifiRoutes listening for incoming DHCP requests
+// Listen reads incoming Ethernet frames from the AF_PACKET socket, parses each
+// DHCPv6 datagram, and dispatches it to HandleMsg6 together with the source MAC
+// address read directly from the Ethernet header.
 func (l *Listener) Listen() error {
 	ll.Debugf("Listen %s", l.ifi.Name)
+	buf := make([]byte, MaxDatagram)
 	for {
-		b := *bufpool.Get().(*[]byte)
-		b = b[:MaxDatagram] //Reslice to max capacity in case the buffer in pool was resliced smaller
-
-		n, oob, peer, err := l.c.ReadFrom(b)
+		n, err := l.rawFile.Read(buf)
 		if err != nil {
-			//ll.Warnf("Error reading from connection: %v", err)
-			return checkNetOpError(err)
+			if errors.Is(err, os.ErrClosed) {
+				return nil
+			}
+			return err
 		}
 
-		go l.HandleMsg6(b[:n], oob, peer.(*net.UDPAddr))
+		srcMAC, dhcpPayload, peer, err := parseEthernetFrame(buf[:n])
+		if err != nil {
+			ll.Debugf("Listen %s: skipping frame: %v", l.ifi.Name, err)
+			continue
+		}
+
+		// Link-local addresses require the interface zone for the reply.
+		peer.Zone = l.ifi.Name
+
+		oob := &ipv6.ControlMessage{IfIndex: l.ifi.Index}
+
+		// Copy the payload out of the shared buffer before handing it to the goroutine.
+		pkt := make([]byte, len(dhcpPayload))
+		copy(pkt, dhcpPayload)
+
+		go l.HandleMsg6(pkt, oob, peer, srcMAC)
 	}
+}
+
+// parseEthernetFrame validates and parses an Ethernet frame containing an IPv6
+// UDP DHCPv6 datagram destined for the DHCPv6 all-servers multicast address.
+// It returns the Ethernet source MAC, the DHCPv6 payload slice (sub-slice of
+// frame), and the UDP source address.
+func parseEthernetFrame(frame []byte) (srcMAC net.HardwareAddr, dhcpPayload []byte, peer *net.UDPAddr, err error) {
+	if len(frame) < etherHeaderLen {
+		return nil, nil, nil, fmt.Errorf("frame too short (%d bytes)", len(frame))
+	}
+
+	if binary.BigEndian.Uint16(frame[12:14]) != etherTypeIPv6 {
+		return nil, nil, nil, fmt.Errorf("not IPv6 (ethertype 0x%04x)", binary.BigEndian.Uint16(frame[12:14]))
+	}
+
+	mac := make(net.HardwareAddr, 6)
+	copy(mac, frame[6:12])
+
+	ipv6Frame := frame[etherHeaderLen:]
+	if len(ipv6Frame) < ipv6HeaderLen {
+		return nil, nil, nil, fmt.Errorf("IPv6 header truncated")
+	}
+
+	if ipv6Frame[6] != 17 { // next header: UDP
+		return nil, nil, nil, fmt.Errorf("not UDP (next header %d)", ipv6Frame[6])
+	}
+
+	if !net.IP(ipv6Frame[24:40]).Equal(dhcpv6.AllDHCPRelayAgentsAndServers) {
+		return nil, nil, nil, fmt.Errorf("not DHCPv6 multicast dst")
+	}
+
+	srcIP := make(net.IP, 16)
+	copy(srcIP, ipv6Frame[8:24])
+
+	udpFrame := ipv6Frame[ipv6HeaderLen:]
+	if len(udpFrame) < udpHeaderLen {
+		return nil, nil, nil, fmt.Errorf("UDP header truncated")
+	}
+
+	if binary.BigEndian.Uint16(udpFrame[2:4]) != uint16(dhcpv6.DefaultServerPort) {
+		return nil, nil, nil, fmt.Errorf("not DHCPv6 server port (%d)", binary.BigEndian.Uint16(udpFrame[2:4]))
+	}
+
+	dhcp := udpFrame[udpHeaderLen:]
+	if len(dhcp) == 0 {
+		return nil, nil, nil, fmt.Errorf("empty DHCPv6 payload")
+	}
+
+	return mac, dhcp, &net.UDPAddr{
+		IP:   srcIP,
+		Port: int(binary.BigEndian.Uint16(udpFrame[0:2])),
+	}, nil
 }

--- a/listener.go
+++ b/listener.go
@@ -144,6 +144,13 @@ func (l *Listener) Listen() error {
 			if errors.Is(err, os.ErrClosed) {
 				return nil
 			}
+			// ENOBUFS: kernel dropped frames because the socket receive buffer
+			// was full (e.g. a burst of DHCPv6 packets).  Log and continue —
+			// this is transient and does not warrant tearing down the listener.
+			if errors.Is(err, syscall.ENOBUFS) {
+				ll.Warnf("Listen %s: receive buffer overflow, frame(s) dropped", l.ifi.Name)
+				continue
+			}
 			return err
 		}
 

--- a/test-e2e.sh
+++ b/test-e2e.sh
@@ -7,7 +7,13 @@
 # Requirements: root (CAP_NET_ADMIN + CAP_NET_RAW), Go toolchain.
 #
 # Usage:
-#   sudo ./test-e2e.sh
+#   sudo ./test-e2e.sh            — full automated test (default)
+#   sudo ./test-e2e.sh setup      — create veth pair + host route, then exit
+#                                   so you can run the daemon manually:
+#                                     sudo ./dhcpd6-unnumbered -regex '^d6test-srv$' \
+#                                       -accept-prefix 2001:db8::/32 -loglevel debug
+#                                     sudo /tmp/dhcpv6test-e2e -interface d6test-cli
+#   sudo ./test-e2e.sh cleanup    — remove the veth pair (no other action)
 #
 # On success  : exits 0  (both test cases passed)
 # On failure  : exits 1  (tail of the daemon log is printed for diagnosis)
@@ -32,6 +38,25 @@ log() { echo "  $*"; }
 die() { echo "FATAL: $*" >&2; exit 1; }
 hdr() { echo; echo "── $* ──"; }
 
+# ── Mode ─────────────────────────────────────────────────────────────────────
+MODE=${1:-test}
+case "$MODE" in
+    test|setup|cleanup) ;;
+    *) echo "usage: $0 [test|setup|cleanup]" >&2; exit 1 ;;
+esac
+
+# cleanup subcommand: just remove the veth pair and exit.
+if [[ "$MODE" == "cleanup" ]]; then
+    hdr "cleanup"
+    if ip link show "$SRV_IF" &>/dev/null; then
+        ip link del "$SRV_IF"
+        log "veth pair ($SRV_IF <-> $CLI_IF) removed"
+    else
+        log "veth pair not found — nothing to do"
+    fi
+    exit 0
+fi
+
 cleanup() {
     hdr "cleanup"
     if [[ -n "${DAEMON_PID:-}" ]] && kill -0 "$DAEMON_PID" 2>/dev/null; then
@@ -46,7 +71,8 @@ cleanup() {
     rm -f "$CLIENT_BIN"
     exit "$EXIT_CODE"
 }
-trap cleanup EXIT INT TERM
+# Only auto-clean in full test mode; setup mode intentionally leaves interfaces up.
+[[ "$MODE" == "test" ]] && trap cleanup EXIT INT TERM
 
 [[ $EUID -eq 0 ]] || die "must run as root"
 cd "$(dirname "$0")"
@@ -127,7 +153,23 @@ fi
 ip -6 route add "$HOST_ROUTE" dev "$SRV_IF"
 log "host route added: $HOST_ROUTE dev $SRV_IF"
 
-# ── Daemon ───────────────────────────────────────────────────────────────────
+# ── Setup mode: hand off to the user ─────────────────────────────────────────
+if [[ "$MODE" == "setup" ]]; then
+    echo
+    echo "╔══════════════════════════════════════════════════════════════════╗"
+    echo "║  veth pair ready — run the daemon and client manually:          ║"
+    echo "║                                                                  ║"
+    printf "║  daemon:  sudo %s \\\\\n" "$DAEMON_BIN"
+    printf "║             -regex '^%s\$' \\\\\n" "$SRV_IF"
+    printf "║             -accept-prefix %s \\\\\n" "$ACCEPT_PFX"
+    echo  "║             -loglevel debug                                     ║"
+    echo  "║                                                                  ║"
+    printf "║  client:  sudo %s -interface %s\n" "$CLIENT_BIN" "$CLI_IF"
+    echo  "║                                                                  ║"
+    printf "║  cleanup: sudo %s cleanup\n" "$0"
+    echo  "╚══════════════════════════════════════════════════════════════════╝"
+    exit 0
+fi
 hdr "starting daemon  (log: $DAEMON_LOG)"
 "$DAEMON_BIN" \
     -regex "^${SRV_IF}$" \

--- a/test-e2e.sh
+++ b/test-e2e.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# test-e2e.sh — end-to-end integration test for dhcpd6-unnumbered.
+#
+# Creates a veth pair, starts the daemon on one end, and uses the dhcpv6test
+# client binary to exercise both the normal-MAC and virtual-MAC paths.
+#
+# Requirements: root (CAP_NET_ADMIN + CAP_NET_RAW), Go toolchain.
+#
+# Usage:
+#   sudo ./test-e2e.sh
+#
+# On success  : exits 0  (both test cases passed)
+# On failure  : exits 1  (tail of the daemon log is printed for diagnosis)
+
+set -euo pipefail
+
+# Go may not be in root's PATH — find it the same way the Makefile does.
+GO=$(command -v go 2>/dev/null || echo /usr/local/go/bin/go)
+[[ -x "$GO" ]] || { echo "FATAL: go binary not found (tried \$PATH and /usr/local/go/bin/go)" >&2; exit 1; }
+
+SRV_IF=d6test-srv
+CLI_IF=d6test-cli
+HOST_ROUTE=2001:db8::1/128    # /128 host route on srv — the address offered to the client
+ACCEPT_PFX=2001:db8::/32      # daemon only offers IPs within this prefix
+DAEMON_LOG=/tmp/dhcpd6-test-daemon.log
+DAEMON_BIN=./dhcpd6-unnumbered
+CLIENT_BIN=/tmp/dhcpv6test-e2e
+DAEMON_PID=
+EXIT_CODE=1
+
+log() { echo "  $*"; }
+die() { echo "FATAL: $*" >&2; exit 1; }
+hdr() { echo; echo "── $* ──"; }
+
+cleanup() {
+    hdr "cleanup"
+    if [[ -n "${DAEMON_PID:-}" ]] && kill -0 "$DAEMON_PID" 2>/dev/null; then
+        kill "$DAEMON_PID"
+        wait "$DAEMON_PID" 2>/dev/null || true
+        log "daemon stopped"
+    fi
+    if ip link show "$SRV_IF" &>/dev/null; then
+        ip link del "$SRV_IF"
+        log "veth pair ($SRV_IF <-> $CLI_IF) removed"
+    fi
+    rm -f "$CLIENT_BIN"
+    exit "$EXIT_CODE"
+}
+trap cleanup EXIT INT TERM
+
+[[ $EUID -eq 0 ]] || die "must run as root"
+cd "$(dirname "$0")"
+
+# ── Build ────────────────────────────────────────────────────────────────────
+hdr "building"
+"$GO" build -o "$DAEMON_BIN" .
+log "daemon:  $DAEMON_BIN"
+"$GO" build -o "$CLIENT_BIN" ./cmd/dhcpv6test
+log "client:  $CLIENT_BIN"
+
+# ── Veth pair ────────────────────────────────────────────────────────────────
+hdr "setting up veth pair  ($SRV_IF <-> $CLI_IF)"
+ip link del "$SRV_IF" 2>/dev/null || true
+ip link add "$SRV_IF" type veth peer name "$CLI_IF"
+ip link set "$SRV_IF" up
+ip link set "$CLI_IF" up
+
+# Wait for both link-local IPv6 addresses and for the server-side TxPackets
+# counter to go positive.  The daemon's linkReady() check requires TxPackets > 0
+# (it was added so the listener isn't started before the link is fully usable —
+# e.g. before the link-local address has been assigned).  The kernel sends NDP
+# Neighbour Solicitations for DAD as soon as a link-local address is configured,
+# which increments TxPackets naturally.
+#
+# We also wait until neither address is in the "tentative" DAD state.  Linux
+# refuses to use a tentative address as the source of outgoing packets
+# (EADDRNOTAVAIL), so the daemon must not start until DAD has completed.
+# On this kernel DAD takes ~2s; we poll up to 5s to be safe.
+echo -n "  waiting for link-local addresses, NDP traffic, and DAD completion"
+SRV_LL= CLI_LL=
+for i in $(seq 1 50); do
+    SRV_LL=$(ip -6 addr show dev "$SRV_IF" scope link 2>/dev/null \
+             | awk '/inet6/{print $2; exit}' | cut -d/ -f1)
+    CLI_LL=$(ip -6 addr show dev "$CLI_IF" scope link 2>/dev/null \
+             | awk '/inet6/{print $2; exit}' | cut -d/ -f1)
+    TX=$(cat /sys/class/net/"$SRV_IF"/statistics/tx_packets 2>/dev/null || echo 0)
+    SRV_TENT=$(ip -6 addr show dev "$SRV_IF" scope link 2>/dev/null | grep -c tentative || true)
+    CLI_TENT=$(ip -6 addr show dev "$CLI_IF" scope link 2>/dev/null | grep -c tentative || true)
+    if [[ -n "$SRV_LL" && -n "$CLI_LL" && "$TX" -gt 0 && "$SRV_TENT" -eq 0 && "$CLI_TENT" -eq 0 ]]; then
+        echo " (ready after $((i * 100))ms)"
+        break
+    fi
+    echo -n "."
+    sleep 0.1
+done
+
+[[ -n "$SRV_LL" ]] || die "no link-local address on $SRV_IF after 5s"
+[[ -n "$CLI_LL" ]] || die "no link-local address on $CLI_IF after 5s"
+
+SRV_TENT=$(ip -6 addr show dev "$SRV_IF" scope link 2>/dev/null | grep -c tentative || true)
+[[ "$SRV_TENT" -eq 0 ]] || die "$SRV_IF link-local address still tentative after 5s — DAD did not complete"
+
+TX=$(cat /sys/class/net/"$SRV_IF"/statistics/tx_packets)
+if [[ "$TX" -eq 0 ]]; then
+    # Veth pair with no traffic yet.  A single ping6 from cli to srv causes srv
+    # to send an ICMP echo reply, satisfying the TxPackets > 0 requirement.
+    log "TxPackets still 0 — sending ping6 to seed NDP/ICMP traffic"
+    ping6 -c 2 -W 1 -I "$CLI_IF" "$SRV_LL" >/dev/null 2>&1 || true
+    TX=$(cat /sys/class/net/"$SRV_IF"/statistics/tx_packets)
+    [[ "$TX" -gt 0 ]] || die "$SRV_IF TxPackets still 0 after ping — linkReady() will never fire"
+fi
+
+log "$SRV_IF  link-local: $SRV_LL  (tx_packets: $TX)"
+log "$CLI_IF  link-local: $CLI_LL"
+
+# Check OperState — the daemon also requires OperState == IF_OPER_UP (6).
+# On modern kernels veth reports UP when both ends are up; warn if not.
+SRV_OPER=$(cat /sys/class/net/"$SRV_IF"/operstate 2>/dev/null || echo unknown)
+if [[ "$SRV_OPER" != "up" ]]; then
+    echo "  WARNING: $SRV_IF operstate is '$SRV_OPER', not 'up'." \
+         "linkReady() requires OperUp — daemon may not bind to this interface."
+fi
+
+# Add the /128 host route that the daemon reads via getHostRoutesIPv6() to
+# decide which address to offer.  Without a matching route, the daemon logs
+# "no host routes" and silently drops all solicits.
+ip -6 route add "$HOST_ROUTE" dev "$SRV_IF"
+log "host route added: $HOST_ROUTE dev $SRV_IF"
+
+# ── Daemon ───────────────────────────────────────────────────────────────────
+hdr "starting daemon  (log: $DAEMON_LOG)"
+"$DAEMON_BIN" \
+    -regex "^${SRV_IF}$" \
+    -accept-prefix "$ACCEPT_PFX" \
+    -dns "2620:fe::9" \
+    -loglevel debug \
+    >"$DAEMON_LOG" 2>&1 &
+DAEMON_PID=$!
+log "pid: $DAEMON_PID"
+
+# Wait until the daemon logs that it has bound to our interface.
+echo -n "  waiting for daemon to bind"
+BOUND=0
+for i in $(seq 1 50); do
+    if grep -q "Starting DHCPv6 server for Interface ${SRV_IF}" "$DAEMON_LOG" 2>/dev/null; then
+        echo " (ready after $((i * 100))ms)"
+        BOUND=1
+        break
+    fi
+    kill -0 "$DAEMON_PID" 2>/dev/null || {
+        echo
+        echo "  daemon exited unexpectedly — last log lines:"
+        tail -20 "$DAEMON_LOG"
+        die "daemon failed to start"
+    }
+    echo -n "."
+    sleep 0.1
+done
+
+if [[ $BOUND -eq 0 ]]; then
+    echo
+    echo "  daemon never bound to $SRV_IF — last log lines:"
+    tail -20 "$DAEMON_LOG"
+    die "daemon did not bind within 5s (check operstate warning above)"
+fi
+
+# ── Test ─────────────────────────────────────────────────────────────────────
+hdr "running dhcpv6test on $CLI_IF"
+if "$CLIENT_BIN" -interface "$CLI_IF" -timeout 4s; then
+    EXIT_CODE=0
+    echo
+    echo "╔══════════════════════════════════╗"
+    echo "║       ALL TESTS PASSED  ✓        ║"
+    echo "╚══════════════════════════════════╝"
+else
+    echo
+    echo "╔══════════════════════════════════╗"
+    echo "║         TESTS FAILED  ✗          ║"
+    echo "╚══════════════════════════════════╝"
+    echo
+    hdr "last 40 lines of daemon log ($DAEMON_LOG)"
+    tail -40 "$DAEMON_LOG"
+fi


### PR DESCRIPTION
We need an option to serve only the "real" MACs, not the virtual generated (distinguished by second smallest bit in the first octet).